### PR TITLE
[jobarray] Fix blocked event loop

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -112,6 +112,10 @@ async function handleJob(taskId, rcl) {
 
         logPidUsage = function(pid) {
             pidusage(pid, function (err, stats) {
+                if (err) {
+                    console.error(`pidusage error ${err.code} for process ${pid}`);
+                    return;
+                }
                 //console.log(stats);
                 // => {
                 //   cpu: 10.0,            // percentage (from 0 to 100*vcore)

--- a/jobexec.js
+++ b/jobexec.js
@@ -35,6 +35,9 @@ async function executeTask(idx) {
         let jobExitCode = await handleJob(tasks[idx], rcl);
         console.log("Task", tasks[idx], "job exit code:", jobExitCode);
         executeTask(idx+1);
+    } else {
+        // No more tasks to handle; stop redis client
+        rcl.quit();
     }
 }
 


### PR DESCRIPTION
Fixed issues with blocked event loop, that prevented process from natural exit:
- `pidusage` error wasn't handled, so it was running infinitely
- `redis` client wasn't closed