### PR TITLE
Add handlerId to logs

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -10,13 +10,16 @@ var pidusage = require('pidusage');
 const si = require('systeminformation');
 const path = require('path');
 const { readEnv } = require('read-env');
+const shortid = require('shortid');
 const RemoteJobConnector = require('./connector');
 
 const {
     procfs,
     ProcfsError,
 } = require('@stroncium/procfs');
- 
+
+const handlerId = shortid.generate();
+
 // FIXME: race here with NFS
 /*if (!fs.existsSync(logDir) {
     fs.mkdirSync(logDir);
@@ -350,13 +353,13 @@ async function handleJob(taskId, rcl) {
     var outputDir = process.env.HF_VAR_OUTPUT_DIR || workDir;
 
     const loglevel = process.env.HF_VAR_LOG_LEVEL || 'info';
-    const logfilename = logDir + '/task-' + taskId.replace(/:/g, '__') + '.log';
-    const stdoutfilename = logDir + '/task-' + taskId.replace(/:/g, '__') + '__stdout.log';
-    const stderrfilename = logDir + '/task-' + taskId.replace(/:/g, '__') + '__stderr.log';
+    const logfilename = logDir + '/task-' + taskId.replace(/:/g, '__') + '@' + handlerId + '.log';
+    const stdoutfilename = logDir + '/task-' + taskId.replace(/:/g, '__') + '@' + handlerId + '__stdout.log';
+    const stderrfilename = logDir + '/task-' + taskId.replace(/:/g, '__') + '@' + handlerId + '__stderr.log';
     var stdoutLog = fs.createWriteStream(stdoutfilename, {flags: 'w'});
     var stderrLog = fs.createWriteStream(stderrfilename, {flags: 'w'});
     const enableNethogs = process.env.HF_VAR_ENABLE_NETHOGS=="1";
-    const nethogsfilename = logDir + '/task-' + taskId.replace(/:/g, '__') + '__nethogs.log';
+    const nethogsfilename = logDir + '/task-' + taskId.replace(/:/g, '__') + '@' + handlerId + '__nethogs.log';
 
     log4js.configure({
         appenders: { hftrace: { type: 'file', filename: logfilename} },
@@ -371,7 +374,7 @@ async function handleJob(taskId, rcl) {
 
     //var rcl = redis.createClient(redisUrl);
 
-    logger.info('handler started');
+    logger.info('handler started, (ID: ' + handlerId + ')');
 
     // 0. Detect multiple task acquisitions
     let totalAcq = await acquireTask(rcl, taskId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "nanoid": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+    },
     "pidtree": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
@@ -141,6 +146,14 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
       "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+    },
+    "shortid": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
+      "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
+      "requires": {
+        "nanoid": "^2.1.0"
+      }
     },
     "streamroller": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "pidusage": "^2.0.18",
     "read-env": "^2.0.0",
     "redis": "^2.8.0",
+    "shortid": "^2.2.15",
     "systeminformation": "^4.22.4"
   }
 }


### PR DESCRIPTION
Currently each executed task produces log files like follow:
```
task-j6Bb_ZBMN__1__12__1.log          
task-j6Bb_ZBMN__1__12__1__nethogs.log 
task-j6Bb_ZBMN__1__12__1__stderr.log  
task-j6Bb_ZBMN__1__12__1__stdout.log  
```
If for some reason there are multiple containers for one task or it's simply re-executed, we end up with mixed logs - see example:
```
10:00 handler started
..
10:01 handler started
...
10:02 handler stopped
...
10:03 handler stopped
```
Thus we cannot determine if both executions took 2 seconds, or maybe 3s and 1s. We might be tended to do something like this:
```
10:00 [144f] handler started
..
10:01 [gr3e] handler started
...
10:02 [gr3e] handler stopped
...
10:03 [144f] handler stopped
```

However this complicates log parsing and requires a lot of change. Instead I propose using **@** + **random handler ID** in log filename to separate logs from each handler/container:
```
task-j6Bb_ZBMN__1__12__1@144f.log
task-j6Bb_ZBMN__1__12__1@ar3e.log
...
```