### PR TITLE
Stopping pidusage without 60s delay

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -427,7 +427,15 @@ async function handleJob(taskId, rcl) {
     // 5. Execute job
     logger.info("Job command: '" + jm["executable"], jm["args"].join(' ') + "'");
     let jobExitCode = await executeJob(jm, 1);
-    log4js.shutdown(function () { return jobExitCode; });
+
+    // 6. Perform cleanup operations
+    log4js.shutdown(function (err) {
+        if (err !== undefined) {
+            logger.error("log4js shutdown error:", err);
+        }
+    });
+    pidusage.clear();
+
     return jobExitCode;
 }
 


### PR DESCRIPTION
When all tasks are completed job-executor is still running - for around 60 sec. That's because of pidusage's intervals which are not stopped. According to [`pidusage` readme](https://github.com/soyuka/pidusage/blob/2779e520d3414a8318c86279cf14bebae3264604/README.md#pidusageclear) for version 2.0.18 we can call pidusage.clear() to stop it without long delay.

**Example**

In case of k8s remote jobs this issue affects execution time - see that `mBgModel` (green) is not started in parallel:
![before_fix](https://user-images.githubusercontent.com/6506780/94657624-fe3a0d00-0301-11eb-87cc-5f99aedc93ec.png)

After this fix:
![after_fix](https://user-images.githubusercontent.com/6506780/94662206-5d9b1b80-0308-11eb-81d5-21ed166e0f44.png)

