### PR TITLE
Allow to separate opts and positional arguments

### DIFF
--- a/jobexec.js
+++ b/jobexec.js
@@ -20,7 +20,7 @@ var docopt = require('docopt').docopt;
 var doc = "\
 Usage:\n\
   hflow-job-execute <taskId> <redisUrl>\n\
-  hflow-job-execute <redisUrl> -a <taskId>...\n\
+  hflow-job-execute <redisUrl> -a [--] <taskId>...\n\
   hflow-job-execute -h | --help";
 
 var opts = docopt(doc);


### PR DESCRIPTION
Some time ago I added [escaping for taskId](https://github.com/hyperflow-wms/hyperflow/pull/41) to hyperflow's k8sJobSubmit(), but I see that still there is problem with hyphen at the beginning:

```
$ hflow-job-execute redis://127.0.0.1:6379 -a "-QkA5ahrv:1:7:1"
Usage:                                                                                                                         
  hflow-job-execute <taskId> <redisUrl>                                                                                        
  hflow-job-execute <redisUrl> -a <taskId>...                                                                                                                                                                                                                  
  hflow-job-execute -h | --help
```

There is no way to escape hyphen, so we should add positional arguments separator `--`:
```
$ hflow-job-execute redis://127.0.0.1:6379 -a -- "-QkA5ahrv:1:7:1"
Job executor will execute tasks: -QkA5ahrv:1:7:1
```

**Note:** this is backward compatible change.